### PR TITLE
Add first-line detection for extensionless G-code files

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
                     ".tap",
                     ".xpi"
                 ],
+                "firstLine": "^\\uFEFF?\\s*%\\s*$",
                 "configuration": "./language/gcode-language.json"
             }
         ],


### PR DESCRIPTION
Many CNC controllers and DNC workflows use extensionless G-code program files.

This adds first-line language detection for files beginning with the standard
standalone % program delimiter, allowing automatic syntax highlighting without
requiring a filename extension.

The pattern allows optional whitespace and UTF-8 BOM characters.
